### PR TITLE
Remove redundant "doctrine/doctrine-cache-bundle" dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "require": {
         "php": "^7.2.5",
         "symfony/http-kernel": "^4.4 || ^5.0",
-        "doctrine/doctrine-cache-bundle": "^1.4",
         "symfony/dependency-injection": "^4.4 || ^5.0",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/framework-bundle": "^4.4 || ^5.0",


### PR DESCRIPTION
Pull request #6 aimed to remove the `doctrine/doctrine-cache-bundle` as a dependency and did so successfully, at least code wise. The `composer.json` file still lists it as a dependency.

I verified that the dependency is in fact unused, using `composer unused` as a tool (please see screenshot below) and removed the corresponding line accordingly.

![composer unused result](https://i.imgur.com/XSzqKfO.png)